### PR TITLE
Bump to 0.22.1

### DIFF
--- a/.github/workflows/monitor-promotion.yml
+++ b/.github/workflows/monitor-promotion.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   monitor-promotion-candidate-to-stable:
-    uses: canonical/robotics-actions-workflows/.github/workflows/channel-risk-sync-monitor.yaml@feat/sync-monitor
+    uses: canonical/robotics-actions-workflows/.github/workflows/channel-risk-sync-monitor.yaml@main

--- a/.github/workflows/monitor-promotion.yml
+++ b/.github/workflows/monitor-promotion.yml
@@ -1,0 +1,8 @@
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  monitor-promotion-candidate-to-stable:
+    uses: canonical/robotics-actions-workflows/.github/workflows/channel-risk-sync-monitor.yaml@feat/sync-monitor

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,14 @@
+name: promote
+
+on:
+  workflow_dispatch:
+
+jobs:
+  snaps:
+    uses: canonical/robotics-actions-workflows/.github/workflows/promote.yaml@main
+    secrets:
+      snapstore-login: ${{ secrets.STORE_LOGIN }}
+    with:
+      snap: rerun
+      from-channel: 'latest/candidate'
+      to-channel: 'latest/stable'

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -7,7 +7,7 @@ jobs:
   snaps:
     uses: canonical/robotics-actions-workflows/.github/workflows/promote.yaml@main
     secrets:
-      snapstore-login: ${{ secrets.STORE_LOGIN }}
+      snapstore-login: ${{ secrets.SNAPSTORE_LOGIN }}
     with:
       snap: rerun
       from-channel: 'latest/candidate'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,7 +37,7 @@ parts:
   rerun:
     plugin: rust
     source: https://github.com/rerun-io/rerun.git
-    source-tag: 0.22.0
+    source-tag: 0.22.1
     build-packages: [nasm]
     rust-cargo-parameters: ["--package", "rerun-cli"]
     rust-no-default-features: True


### PR DESCRIPTION
Bump the snap to 0.22.1 & add a couple missing workflows.

Closes #13 .

Depends on https://github.com/canonical/robotics-actions-workflows/pull/15.